### PR TITLE
Use special outcome codes for close issues and 311 feedback

### DIFF
--- a/config.py
+++ b/config.py
@@ -45,6 +45,14 @@ CONFIG = {
             "Send Email": None,
             "Coordinate Internally/Externally": "COORINTE",
         },
+        "outcome_codes": {
+            # "ISHABRCS: Issue has been resolved - this outcome code ensures the SR is actually closed"
+            "Close Issue (Duplicate)": "ISHABRCS",
+            "Close Issue (Resolved)": "ISHABRCS",
+            # "ADRERECS: Additional review required - ensure something special happens in CSR"
+            "311 Feedback": "ADRERECS",
+            "default": "COMPLET1"
+        }
     },
     "signs-markings": {
         "obj": "object_173",
@@ -79,5 +87,13 @@ CONFIG = {
             "311 Feedback": "311FEEDB",
             "Other": None,
         },
+        "outcome_codes": {
+            # "ISHABRCS: Issue has been resolved - this outcome code ensures the SR is actually closed"
+            "Close Issue (Duplicate)": "ISHABRCS",
+            "Close Issue (Resolved)": "ISHABRCS",
+            # "ADRERECS: Additional review required - ensure something special happens in CSR"
+            "311 Feedback": "ADRERECS",
+            "default": "COMPLET1"
+        }
     },
 }

--- a/message_template.xml
+++ b/message_template.xml
@@ -27,7 +27,7 @@
           <issue_status_code>{issue_status_code_snapshot}</issue_status_code>
           <activity_type_code>{csr_activity_code}</activity_type_code>
           <activity_details>{activity_details}</activity_details>
-          <outcome_code>COMPLET1</outcome_code>
+          <outcome_code>{csr_outcome_code}</outcome_code>
           <activity_date>{activity_datetime}</activity_date>
         </csr>
       </data>

--- a/send_knack_messages_to_esb.py
+++ b/send_knack_messages_to_esb.py
@@ -111,10 +111,9 @@ def build_template_dict(*, record, fields, activity_codes, outcome_codes):
             raise ValueError(
                 f"Activity name has no corresponding activity type code in 311 CSR: {activity_name}"
             )
-
     # assign outcome code based on activity code
-    activity_code = template_dict["csr_activity_code"]
-    outcome_code = outcome_codes.get(activity_code, outcome_codes["default"])
+    activity_name = template_dict["activity_name"]
+    outcome_code = outcome_codes.get(activity_name, outcome_codes["default"])
     template_dict["csr_outcome_code"] = outcome_code
 
     """311 and Knack to do not agree on what counts as a duplicate issue. This is because

--- a/send_knack_messages_to_esb.py
+++ b/send_knack_messages_to_esb.py
@@ -82,7 +82,7 @@ def get_record_filter(*, fields):
     return filters
 
 
-def build_template_dict(*, record, fields, activity_codes):
+def build_template_dict(*, record, fields, activity_codes, outcome_codes):
     """Prepares the data that will populate the xml message template.
 
     Args:
@@ -111,6 +111,11 @@ def build_template_dict(*, record, fields, activity_codes):
             raise ValueError(
                 f"Activity name has no corresponding activity type code in 311 CSR: {activity_name}"
             )
+
+    # assign outcome code based on activity code
+    activity_code = template_dict["csr_activity_code"]
+    outcome_code = outcome_codes.get(activity_code, outcome_codes["default"])
+    template_dict["csr_outcome_code"] = outcome_code
 
     """311 and Knack to do not agree on what counts as a duplicate issue. This is because
     311 CSR has a built-in system for flagging dupe SRs based on the SR location. However,
@@ -247,6 +252,7 @@ def main(app_name):
             record=record_formatted,
             fields=config["fields"],
             activity_codes=config["activity_codes"],
+            outcome_codes=config["outcome_codes"],
         )
 
         if template_dict["csr_activity_code"]:


### PR DESCRIPTION
Resolves https://github.com/cityofaustin/atd-data-tech/issues/17241

This SR adds new outcome codes to 311 activity updates based on the activity type. Whereas we used to hardcode the outcome code to a single value, we are making this change to comply with business rules in the CSR system. I've written this code in a way that will enable to add other activity-specific outcome codes in the future. 


## Testing

Testing this is not fun! You can follow the steps in the readme to configure an end-to-end test setup, although I'm not totally sure the ESB test environment will work, because I believe our API keys may have already de-sync'd with what is stored there. I have only tested this PR without interfacing with the ESB/CSR. I've done so by adding a breakpoint and `continue` statement [right here](https://github.com/cityofaustin/atd-knack-311/blob/3f790759f83ec06a20734aa4a8ce514e8240f73c/send_knack_messages_to_esb.py#L281).

For deployment to prod, we'll just want to keep a close on this over the course of a day and make sure the updates are having the intended effect. We'll want to coordinate that with Patrick + Carrie @ 311 to ensure they're on standby as well.


