### PR TITLE
Update activity code mapping for "Remote Monitor Reset - Unsuccessful"

### DIFF
--- a/config.py
+++ b/config.py
@@ -34,7 +34,7 @@ CONFIG = {
             "Monitor Situation in KITS": "MONISSRE",
             "Close Issue (Duplicate)": "CLOIS001",
             "Remote Monitor Reset - Successful": "REMORESU",
-            "Remote Monitor Reset - Unsuccessful": "REMOR001",
+            "Remote Monitor Reset - Unsuccessful": "REMOREUN",
             "Other": None,
             "Storm-Related": None,
             "Adjust Video Detection": "ADJVIDDE",


### PR DESCRIPTION
As part of  https://github.com/cityofaustin/atd-data-tech/issues/25688, we discovered that we have an invalid mapping of an activity code used by Arterial Management. Apparently it's an activity that AMD rarely (never?) uses.

I am not looking for anyone to test this because it has been heavily tested as part of the  Knack <> Boomi <> 311 integration upgrades. 