### PR TITLE
Log XML message payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The script currently supports two Knack apps: the AMD Data Tracker and the Signs
 
 ### Environment
 
-It is possible to run end-to-end tests of all systems involved in the Knack <> 311 integration. The test system credentials are available in our password store and include additional documentation.
+It is possible to run end-to-end tests of all systems involved in the Knack <> 311 integration. The test system credentials are available in 1Password under the name **CTM Boomi aka Enterprise Service Bus - ESB - 311 Interface**.
 
 The following environment variables are required.
 
@@ -25,7 +25,7 @@ The following environment variables are required.
 
 ### Certificates
 
-A self-signed certificate and key must be present in the project's root directory and saved as `esb.cert` and `esb.pem` respectively.
+A self-signed certificate and key must be present in the project's root directory and saved as `esb.cert` and `esb.pem` respectively. The certificate files are available in 1Password under the item called **CTM Boomi aka Enterprise Service Bus - ESB - 311 Interface**.
 
 ### Field Mappings (`config.py`)
 

--- a/send_knack_messages_to_esb.py
+++ b/send_knack_messages_to_esb.py
@@ -245,9 +245,11 @@ def main(app_name):
         )
 
         if template_dict["csr_activity_code"]:
+            logger.info(f"Message payload:\n{template_dict}\n\n")
+
             message = build_xml_payload(template_dict)
 
-            logger.info(f"Sending payload {template_dict}")
+            logger.info(f"Message XML:\n{message}\n\n")
 
             send_message(message=message, endpoint=ESB_ENDPOINT)
 


### PR DESCRIPTION
I'd like to log the XML message payload in this ETL because it is something that the ESB team asks for when we report issues.

Eyeball test would be good since the ESB endpoint is currently offline anyway.

```
send_esb_message.INFO: Processing Knack > 311 messages for app: data-tracker
 send_esb_message.INFO: Initializing knackpy.App...
 send_esb_message.INFO: Fetching records...
 send_esb_message.INFO: 3 records to process.
 send_esb_message.INFO: Message payload:
{'id': '6a4bcdb0328c951f2b5f071d', 'atd_activity_id': 387195, 'emi_id': '20260706104008_26-00221566', 'sr_number': '26-00221566', 'esb_status': 'READY_TO_SEND', 'activity_datetime': '2026-07-06T10:45:00-05:00', 'activity_details': 'Keep getting reports that the NBL at Sendero Hills Pkwy / Loyola doesn&amp;apos;t have enough time but everytime I check on camera it looks good.', 'activity_name': 'Assign to Signal Engineering', 'csr_activity_id': '', 'csr_activity_code': 'ASTOSIEN', 'csr_outcome_code': 'COMPLET1', 'publication_datetime': '2026-07-06T16:35:42.491655+00:00'}


 send_esb_message.INFO: Message XML:
<soapenv:Envelope
  xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
  xmlns:acc="http://www.austintexas.gov/AcceptKnack/">
  <soapenv:Header/>
  <soapenv:Body>
    <acc:submitKnack>
      <header>
        <emi>20260706104008_26-00221566</emi>
        <!-- blank -->
        <timestamp>2026-07-06T16:35:42.491655+00:00</timestamp>
        <!-- time of publication in unix milliseconds -->
        <source>KNACK</source>
        <!--  constant -->
        <target>CSR</target>
        <!-- constant -->
        <data_type>CSR</data_type>
        <!-- constant -->
        <event>UPDATE</event>
        <!-- constant -->
      </header>
      <data>
        <csr>
          <!--   knack activity record id -->
          <id>6a4bcdb0328c951f2b5f071d</id>
          <csr_activity_id></csr_activity_id>
          <sr_number>26-00221566</sr_number>
          <activity_type_code>ASTOSIEN</activity_type_code>
          <activity_details>Keep getting reports that the NBL at Sendero Hills Pkwy / Loyola doesn&amp;apos;t have enough time but everytime I check on camera it looks good.</activity_details>
          <outcome_code>COMPLET1</outcome_code>
          <activity_date>2026-07-06T10:45:00-05:00</activity_date>
        </csr>
      </data>
    </acc:submitKnack>
  </soapenv:Body>
</soapenv:Envelope>
```